### PR TITLE
Fix login email field

### DIFF
--- a/client/src/features/auth/LoginForm.tsx
+++ b/client/src/features/auth/LoginForm.tsx
@@ -14,7 +14,7 @@ import { Loader } from '@/components/ui/Loader';
 
 // Form validation schema using Zod
 const loginSchema = z.object({
-  username: z.string().min(1, 'Username or email is required'),
+  email: z.string().min(1, 'Email is required').email('Invalid email address'),
   password: z.string().min(1, 'Password is required'),
   rememberMe: z.boolean().optional().default(false),
 });
@@ -38,7 +38,7 @@ export default function LoginForm({ onSuccess, redirectTo }: LoginFormProps) {
   const form = useForm<LoginFormValues>({
     resolver: zodResolver(loginSchema),
     defaultValues: {
-      username: '',
+      email: '',
       password: '',
       rememberMe: false,
     },
@@ -49,7 +49,7 @@ export default function LoginForm({ onSuccess, redirectTo }: LoginFormProps) {
     try {
       setError(null);
       const success = await login({
-        username: values.username,
+        username: values.email,
         password: values.password,
         rememberMe: values.rememberMe,
       });
@@ -94,19 +94,20 @@ export default function LoginForm({ onSuccess, redirectTo }: LoginFormProps) {
             </Alert>
           )}
           
-          {/* Username/Email field */}
+          {/* Email field */}
           <FormField
             control={form.control}
-            name="username"
+            name="email"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Username or Email</FormLabel>
+                <FormLabel>Email</FormLabel>
                 <FormControl>
-                  <Input 
-                    placeholder="Enter your username or email" 
-                    {...field} 
+                  <Input
+                    type="email"
+                    placeholder="Enter your email"
+                    {...field}
                     disabled={isLoading}
-                    autoComplete="username"
+                    autoComplete="email"
                   />
                 </FormControl>
                 <FormMessage />

--- a/client/src/features/auth/authHooks.ts
+++ b/client/src/features/auth/authHooks.ts
@@ -68,7 +68,13 @@ export function useAuth() {
   
   // Login method
   const login = async (credentials: UserCredentials) => {
-    const resultAction = await dispatch(loginAction(credentials));
+    const resultAction = await dispatch(
+      loginAction({
+        email: (credentials as any).email || credentials.username,
+        password: credentials.password,
+        rememberMe: (credentials as any).rememberMe ?? credentials.remember,
+      })
+    );
     
     if (loginAction.fulfilled.match(resultAction)) {
       toast.success({ 


### PR DESCRIPTION
## Summary
- fix LoginForm to send email to login action
- map `UserCredentials` to login API format

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node' and 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_683f48edb8488323a290233877019f0c