### PR TITLE
Fix search page redirection for guests

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,7 +2,7 @@ import React, { Suspense, lazy, useState, useEffect } from "react";
 import { Switch, Route, useLocation, useRoute, Redirect } from "wouter";
 import NotFound from "@/pages/not-found";
 import Layout from "@/components/layout/Layout";
-import { UserRole } from "@/config/navigation";
+import { UserRole } from "@/types";
 import { useAuth } from "@/hooks/useAuth";
 import { useToast } from "@/hooks/use-toast";
 import { Button } from "@/components/ui/button";
@@ -11,6 +11,7 @@ import OfflineIndicator from "@/components/OfflineIndicator";
 import NavigationToast from "@/features/navigation/NavigationToast";
 import { Toaster } from "@/components/ui/toaster";
 import { Loader2 } from "lucide-react";
+import { canAccessRoute } from "@/features/auth/rbac";
 
 // Global loading component for lazy-loaded routes
 const GlobalLoadingFallback = () => (
@@ -303,10 +304,13 @@ function AppRouter() {
   const [isSignupMatch] = useRoute("/signup");
   const [isOnline, setIsOnline] = useState<boolean>(navigator.onLine);
 
-  // Redirect to login if not authenticated and not already on login/signup page
+  // Redirect to login only if the current route requires authentication
   useEffect(() => {
     if (!isLoading && !isAuthenticated && !isLoginMatch && !isSignupMatch) {
-      navigate("/login");
+      const { canAccess } = canAccessRoute(location, UserRole.GUEST);
+      if (!canAccess) {
+        navigate("/login");
+      }
     }
   }, [isLoading, isAuthenticated, isLoginMatch, isSignupMatch, navigate, location]);
 

--- a/client/src/components/ui/UserMenu.tsx
+++ b/client/src/components/ui/UserMenu.tsx
@@ -3,7 +3,6 @@ import { useAppDispatch } from '@/app/hooks';
 import { logout } from '@/features/auth/authSlice';
 import { cn } from '@/lib/utils';
 import { User } from '@/features/auth/types';
-import { UserRole } from '@/config/navigation';
 import { Link } from 'wouter';
 
 interface UserMenuProps {

--- a/client/src/components/ui/header.tsx
+++ b/client/src/components/ui/header.tsx
@@ -20,7 +20,7 @@ import { NotificationBell } from '@/features/notifications/components/Notificati
 // Import cart and wishlist state from Redux store
 import { RootState } from '@/app/store';
 import { useAppSelector } from '@/app/hooks';
-import { UserRole } from '@/config/navigation';
+import type { UserRole } from '@/types';
 import { selectCartItemsCount } from '@/features/cart/cartSlice';
 
 import {

--- a/client/src/features/auth/authSlice.ts
+++ b/client/src/features/auth/authSlice.ts
@@ -2,7 +2,7 @@ import { createSlice, createAsyncThunk, createAction, PayloadAction } from '@red
 import { RootState } from '@/app/store';
 import { apiRequest } from '@/lib/queryClient';
 import { User, UserStatus } from './types';
-import { UserRole } from '@/config/navigation';
+import type { UserRole } from '@/types';
 
 /**
  * Authentication slice for Redux Toolkit

--- a/client/src/features/auth/types.ts
+++ b/client/src/features/auth/types.ts
@@ -1,5 +1,5 @@
 // Authentication Types
-import { UserRole } from '@/config/navigation';
+import type { UserRole } from '@/types';
 
 export enum UserStatus {
   ACTIVE = 'active',


### PR DESCRIPTION
## Summary
- check route's access requirements before forcing login redirect
- import `UserRole` enum from `@/types`

## Testing
- `npm run check` *(fails: missing type definitions)*
- `./run-tests.sh` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683f4aa11d888323bc421c39d9785227