### PR TITLE
Add additional unit tests

### DIFF
--- a/client/src/features/auth/authSlice.test.ts
+++ b/client/src/features/auth/authSlice.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import authReducer, { logout, setCredentials, checkTokenExpiration } from './authSlice';
+
+const baseUser = { id: '1', username: 'demo', role: 'user' } as any;
+
+const initialState = authReducer(undefined, { type: 'init' });
+
+describe('authSlice reducers', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it('sets credentials and authenticates the user', () => {
+    const state = authReducer(
+      initialState,
+      setCredentials({
+        user: baseUser,
+        token: 'token',
+        refreshToken: 'refresh',
+        expiresAt: 123,
+      })
+    );
+
+    expect(state.user).toEqual(baseUser);
+    expect(state.token).toBe('token');
+    expect(state.isAuthenticated).toBe(true);
+  });
+
+  it('clears state on logout', () => {
+    const loggedIn = authReducer(
+      initialState,
+      setCredentials({ user: baseUser, token: 't', refreshToken: 'r', expiresAt: 1 })
+    );
+
+    const state = authReducer(loggedIn, logout());
+
+    expect(state.user).toBeNull();
+    expect(state.token).toBeNull();
+    expect(state.isAuthenticated).toBe(false);
+  });
+});
+
+describe('checkTokenExpiration', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('dispatches refresh when token is expired and refresh token exists', () => {
+    const dispatch = vi.fn();
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const getState = () => ({
+      auth: { expiresAt: Math.floor(now / 1000) - 10, refreshToken: 'r' }
+    });
+
+    const result = checkTokenExpiration()(dispatch, getState as any);
+
+    expect(result).toBe(true);
+    expect(dispatch).toHaveBeenCalled();
+  });
+
+  it('dispatches logout when expired without refresh token', () => {
+    const dispatch = vi.fn();
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const getState = () => ({
+      auth: { expiresAt: Math.floor(now / 1000) - 10, refreshToken: null }
+    });
+
+    const result = checkTokenExpiration()(dispatch, getState as any);
+
+    expect(result).toBe(true);
+    expect(dispatch).toHaveBeenCalled();
+  });
+
+  it('returns false when token is valid', () => {
+    const dispatch = vi.fn();
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const getState = () => ({
+      auth: { expiresAt: Math.floor(now / 1000) + 100, refreshToken: 'r' }
+    });
+
+    const result = checkTokenExpiration()(dispatch, getState as any);
+
+    expect(result).toBe(false);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/features/cart/cartSlice.test.ts
+++ b/client/src/features/cart/cartSlice.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import cartReducer, {
+  addToCart,
+  removeFromCart,
+  updateQuantity,
+  selectCartItemsCount,
+  selectCartTotal,
+} from './cartSlice';
+
+const baseCart = {
+  id: 'cart1',
+  items: [],
+  totals: {
+    subtotal: 0,
+    discountTotal: 0,
+    taxTotal: 0,
+    shippingTotal: 0,
+    total: 0,
+    currency: 'USD',
+  },
+  coupons: [],
+  createdAt: '2023-01-01T00:00:00Z',
+  updatedAt: '2023-01-01T00:00:00Z',
+  isDigitalOnly: true,
+  convertedToOrder: false,
+};
+
+const initialState = {
+  cart: { ...baseCart },
+  status: 'idle',
+  error: null,
+  savedItems: [],
+};
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('cartSlice reducers', () => {
+  it('adds items to the cart', () => {
+    const state = cartReducer(
+      initialState,
+      addToCart({
+        productId: 'p1',
+        product: { name: 'Test', brand: { id: 'b', name: 'Brand', slug: 'b' } },
+        quantity: 2,
+        unitPrice: 10,
+        discountTotal: 0,
+        sku: 'sku1',
+        isDigital: false,
+        requiresShipping: true,
+        isTaxExempt: false,
+        weight: 1,
+      })
+    );
+
+    expect(state.cart.items.length).toBe(1);
+    expect(state.cart.totals.subtotal).toBe(20);
+  });
+
+  it('updates item quantity', () => {
+    let state = cartReducer(
+      initialState,
+      addToCart({
+        productId: 'p1',
+        product: { name: 'Test', brand: { id: 'b', name: 'Brand', slug: 'b' } },
+        quantity: 1,
+        unitPrice: 5,
+        discountTotal: 0,
+        sku: 'sku1',
+        isDigital: false,
+        requiresShipping: true,
+        isTaxExempt: false,
+        weight: 1,
+      })
+    );
+    const id = state.cart.items[0].id;
+    state = cartReducer(state, updateQuantity({ id, quantity: 3 }));
+    expect(state.cart.items[0].quantity).toBe(3);
+  });
+
+  it('removes items from the cart', () => {
+    let state = cartReducer(
+      initialState,
+      addToCart({
+        productId: 'p1',
+        product: { name: 'Test', brand: { id: 'b', name: 'Brand', slug: 'b' } },
+        quantity: 1,
+        unitPrice: 5,
+        discountTotal: 0,
+        sku: 'sku1',
+        isDigital: false,
+        requiresShipping: true,
+        isTaxExempt: false,
+        weight: 1,
+      })
+    );
+    const id = state.cart.items[0].id;
+    state = cartReducer(state, removeFromCart(id));
+    expect(state.cart.items.length).toBe(0);
+  });
+});
+
+describe('cartSlice selectors', () => {
+  it('selects totals and counts', () => {
+    const state = cartReducer(
+      initialState,
+      addToCart({
+        productId: 'p1',
+        product: { name: 'Test', brand: { id: 'b', name: 'Brand', slug: 'b' } },
+        quantity: 2,
+        unitPrice: 10,
+        discountTotal: 0,
+        sku: 'sku1',
+        isDigital: false,
+        requiresShipping: true,
+        isTaxExempt: false,
+        weight: 1,
+      })
+    );
+
+    const rootState: any = { cart: state };
+    expect(selectCartItemsCount(rootState)).toBe(1);
+    expect(selectCartTotal(rootState)).toBeCloseTo(21.6, 1);
+  });
+});

--- a/client/src/features/products/components/ProductDetails.test.tsx
+++ b/client/src/features/products/components/ProductDetails.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, waitFor } from '@testing-library/react';
+import ProductDetails from './ProductDetails';
+import { renderWithProviders } from '@/test/test-utils';
+import * as api from '../productsApi';
+import * as hooks from '@/app/hooks';
+import { useToast } from '@/hooks/use-toast';
+import * as wouter from 'wouter';
+
+vi.mock('../productsApi');
+vi.mock('@/app/hooks');
+vi.mock('@/hooks/use-toast');
+vi.mock('wouter');
+
+describe('ProductDetails', () => {
+  it('adds item to cart when button is clicked', async () => {
+    (wouter.useParams as unknown as vi.Mock).mockReturnValue({ id: '1' });
+
+    (api.useGetProductByIdQuery as unknown as vi.Mock).mockReturnValue({
+      data: { id: 1, name: 'Test', price: 10, sku: 'sku1', brand: 'Brand', inStock: true },
+      isLoading: false,
+    });
+    (api.useGetProductsQuery as unknown as vi.Mock).mockReturnValue({
+      data: { products: [] },
+      isLoading: false,
+    });
+
+    const mockDispatch = vi.fn();
+    (hooks.useAppDispatch as unknown as vi.Mock).mockReturnValue(mockDispatch);
+
+    const mockToast = vi.fn();
+    (useToast as unknown as vi.Mock).mockReturnValue({ toast: mockToast });
+
+    const { getByText } = renderWithProviders(<ProductDetails />, { route: '/product/1' });
+    fireEvent.click(getByText(/add to cart/i));
+
+    await waitFor(() => expect(mockDispatch).toHaveBeenCalled());
+    expect(mockToast).toHaveBeenCalled();
+  });
+});

--- a/client/src/features/products/productsSlice.test.ts
+++ b/client/src/features/products/productsSlice.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import productsReducer, {
+  clearImageUploadState,
+  setFilter,
+  resetFilters,
+  uploadProductImages,
+  selectFilters
+} from './productsSlice';
+
+const initialState = productsReducer(undefined, { type: 'init' });
+
+describe('productsSlice reducers', () => {
+  it('clears image upload state', () => {
+    const modified = {
+      ...initialState,
+      imageUpload: { status: 'loading', error: 'e', uploadedImageUrls: ['a'] }
+    } as any;
+
+    const state = productsReducer(modified, clearImageUploadState());
+    expect(state.imageUpload).toEqual({ status: 'idle', error: null, uploadedImageUrls: [] });
+  });
+
+  it('sets filter values', () => {
+    const state = productsReducer(
+      initialState,
+      setFilter({ key: 'category', value: 'books' })
+    );
+    expect(state.filters.category).toBe('books');
+  });
+
+  it('resets filters', () => {
+    const mod = productsReducer(initialState, setFilter({ key: 'category', value: 'books' }));
+    const state = productsReducer(mod, resetFilters());
+    expect(state.filters).toEqual(initialState.filters);
+  });
+});
+
+describe('productsSlice extra reducers', () => {
+  it('handles uploadProductImages lifecycle', () => {
+    let state = productsReducer(initialState, { type: uploadProductImages.pending.type });
+    expect(state.imageUpload.status).toBe('loading');
+
+    state = productsReducer(state, {
+      type: uploadProductImages.fulfilled.type,
+      payload: { imageUrls: ['one', 'two'] }
+    });
+    expect(state.imageUpload.status).toBe('succeeded');
+    expect(state.imageUpload.uploadedImageUrls).toEqual(['one', 'two']);
+
+    state = productsReducer(state, {
+      type: uploadProductImages.rejected.type,
+      payload: 'err'
+    });
+    expect(state.imageUpload.status).toBe('failed');
+    expect(state.imageUpload.error).toBe('err');
+  });
+});
+
+describe('productsSlice selectors', () => {
+  it('selects filters', () => {
+    const root = { products: initialState } as any;
+    expect(selectFilters(root)).toEqual(initialState.filters);
+  });
+});

--- a/client/src/lib/utils.test.ts
+++ b/client/src/lib/utils.test.ts
@@ -1,5 +1,18 @@
 import { describe, it, expect } from 'vitest';
-import { cn, formatNumber, formatCurrency, formatTimeAgo } from './utils';
+import {
+  cn,
+  formatNumber,
+  formatCurrency,
+  formatTimeAgo,
+  formatDate,
+  formatTime,
+  truncateText,
+  generateId,
+  debounce,
+  capitalizeFirstLetter,
+  isEmptyObject,
+  removeDuplicates
+} from './utils';
 
 describe('Utility Functions', () => {
   describe('cn function', () => {
@@ -111,6 +124,49 @@ describe('Utility Functions', () => {
       const twoYearsAgo = new Date(now.getTime() - 2 * 365 * 24 * 60 * 60 * 1000);
       
       expect(formatTimeAgo(twoYearsAgo)).toBe('2 years ago');
+    });
+  });
+});
+  describe('additional utility functions', () => {
+    it('formats a date string', () => {
+      expect(formatDate('2023-01-01T00:00:00Z')).toBe('January 1, 2023');
+    });
+
+    it('formats time', () => {
+      const timestamp = Date.parse('2023-01-01T12:00:00Z');
+      expect(formatTime(timestamp)).toMatch(/12:00/);
+    });
+
+    it('truncates text', () => {
+      expect(truncateText('Hello world', 5)).toBe('Hello...');
+    });
+
+    it('generates id of length 7', () => {
+      expect(generateId()).toMatch(/^[a-z0-9]{7}$/);
+    });
+
+    it('debounces function calls', () => {
+      vi.useFakeTimers();
+      const fn = vi.fn();
+      const debounced = debounce(fn, 100);
+      debounced();
+      debounced();
+      vi.advanceTimersByTime(100);
+      expect(fn).toHaveBeenCalledTimes(1);
+      vi.useRealTimers();
+    });
+
+    it('capitalizes first letter', () => {
+      expect(capitalizeFirstLetter('hello')).toBe('Hello');
+    });
+
+    it('checks empty object', () => {
+      expect(isEmptyObject({})).toBe(true);
+      expect(isEmptyObject({ a: 1 })).toBe(false);
+    });
+
+    it('removes duplicates', () => {
+      expect(removeDuplicates([1, 1, 2, 3])).toEqual([1, 2, 3]);
     });
   });
 });

--- a/client/src/utils/dateTime.test.ts
+++ b/client/src/utils/dateTime.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatDate,
+  formatRelativeTime,
+  addTime,
+  getDateDiff,
+  isDateBetween,
+  formatShortDate,
+  parseDate,
+} from './dateTime';
+
+describe('dateTime utilities', () => {
+  it('formats dates correctly', () => {
+    const date = new Date('2023-01-01T00:00:00Z');
+    expect(formatDate(date, { locale: 'en-US' })).toBe('January 1, 2023');
+  });
+
+  it('returns "Invalid date" for bad input', () => {
+    expect(formatDate('not-a-date' as any)).toBe('Invalid date');
+  });
+
+  it('formats relative time in the past', () => {
+    const past = Date.now() - 3 * 60 * 1000; // 3 minutes ago
+    expect(formatRelativeTime(past)).toBe('3 minutes ago');
+  });
+
+  it('formats relative time in the future', () => {
+    const future = Date.now() + 5 * 60 * 1000; // 5 minutes from now
+    expect(formatRelativeTime(future)).toBe('in 5 minutes');
+  });
+
+  it('adds time to a date', () => {
+    const base = new Date('2023-01-01T00:00:00Z');
+    const result = addTime(base, 2, 'days');
+    expect(result.getDate()).toBe(3);
+  });
+
+  it('computes date differences', () => {
+    const start = new Date('2023-01-01T00:00:00Z');
+    const end = new Date('2023-01-03T00:00:00Z');
+    expect(getDateDiff(start, end, 'days')).toBe(2);
+  });
+
+  it('checks dates between range', () => {
+    const date = new Date('2023-01-15');
+    expect(
+      isDateBetween(date, new Date('2023-01-10'), new Date('2023-01-20'))
+    ).toBe(true);
+  });
+
+  it('formats short date', () => {
+    const date = new Date('2023-01-05T00:00:00Z');
+    expect(formatShortDate(date)).toBe('01/05/2023');
+  });
+
+  it('parses common date formats', () => {
+    const d1 = parseDate('01/05/2023');
+    const d2 = parseDate('2023-01-05', 'YYYY-MM-DD');
+    expect(d1?.getFullYear()).toBe(2023);
+    expect(d2?.getDate()).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary
- cover auth reducers and token expiration check
- test product slice reducers and async lifecycle
- extend utility tests for misc helpers

## Testing
- `./run-tests.sh` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_683f4c87cfc883239a508a138f505e01