### PR TITLE
Add dashboard route handling

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -66,6 +66,14 @@ export const routes = [
     roles: ['user', 'admin', 'seller', 'moderator'] as UserRole[],
   },
   {
+    path: "/dashboard",
+    component: Dashboard,
+    exact: true,
+    requireAuth: true,
+    title: "Dashboard",
+    roles: ['user', 'admin', 'seller', 'moderator'] as UserRole[],
+  },
+  {
     path: "/login",
     component: LoginPage,
     requireAuth: false,

--- a/client/src/features/auth/rbac.ts
+++ b/client/src/features/auth/rbac.ts
@@ -172,6 +172,11 @@ export const ROUTE_CONFIG: Record<string, RouteConfig> = {
   '/': {
     requireAuth: false,
   },
+  '/dashboard': {
+    requireAuth: true,
+    permissions: ['dashboard:access'],
+    redirectTo: '/login',
+  },
   '/login': {
     requireAuth: false,
   },

--- a/client/src/features/navigation/NavigationToast.tsx
+++ b/client/src/features/navigation/NavigationToast.tsx
@@ -22,6 +22,7 @@ const NavigationToast = () => {
     // Define routes map
     const pathToTitle: Record<string, string> = {
       "/": "Dashboard",
+      "/dashboard": "Dashboard",
       "/login": "Login",
       "/signup": "Sign Up",
       "/products": "Products",

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -65,6 +65,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
     res.redirect('/login');
   });
 
+  // Redirect legacy dashboard path to root
+  app.get('/dashboard', (_req, res) => {
+    res.redirect('/');
+  });
+
   // API Status endpoint
   app.get('/api/status', (req, res) => {
     res.json([


### PR DESCRIPTION
## Summary
- add `/dashboard` route in client router
- allow dashboard route in RBAC map
- add `/dashboard` route to navigation toast titles
- redirect server-side `/dashboard` path to root

## Testing
- `./run-tests.sh` *(fails: 403 Forbidden for npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_683f54f89bc88323818185351de992bc