### PR TITLE
Add test scripts and fix utils test

### DIFF
--- a/client/src/lib/utils.test.ts
+++ b/client/src/lib/utils.test.ts
@@ -126,7 +126,7 @@ describe('Utility Functions', () => {
       expect(formatTimeAgo(twoYearsAgo)).toBe('2 years ago');
     });
   });
-});
+
   describe('additional utility functions', () => {
     it('formats a date string', () => {
       expect(formatDate('2023-01-01T00:00:00Z')).toBe('January 1, 2023');

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "vitest run",
+    "setup": "node scripts/local-setup.js"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Summary
- add `test` and `setup` scripts to package.json
- fix unmatched closing brace in `utils.test.ts`

## Testing
- `npm test` *(fails: navigator.connection.addEventListener is not a function, other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_683f59a2301483238b4b7b2c40e39d6a