### PR TITLE
Fix dashboard API routes and UI tweaks

### DIFF
--- a/client/src/components/dashboard/MetricCard.tsx
+++ b/client/src/components/dashboard/MetricCard.tsx
@@ -20,7 +20,7 @@ export default function MetricCard({
   linkHref,
 }: MetricCardProps) {
   return (
-    <div className="bg-white dark:bg-slate-800 overflow-hidden shadow rounded-lg">
+    <div className="bg-white dark:bg-slate-800 overflow-hidden shadow rounded-lg transition-transform hover:scale-105 hover:shadow-lg">
       <div className="p-5">
         <div className="flex items-center">
           <div className="flex-shrink-0">

--- a/client/src/components/dashboard/QuickActions.tsx
+++ b/client/src/components/dashboard/QuickActions.tsx
@@ -85,10 +85,10 @@ export default function QuickActions() {
       </div>
       <div className="p-6">
         <div className="grid grid-cols-2 gap-4">
-          <button 
+          <button
             onClick={handleCreateUser}
             disabled={isCreatingUser}
-            className="py-3 px-4 bg-slate-50 dark:bg-slate-700 hover:bg-slate-100 dark:hover:bg-slate-600 rounded-lg text-center disabled:opacity-50 disabled:cursor-not-allowed"
+            className="py-3 px-4 bg-slate-50 dark:bg-slate-700 hover:bg-slate-100 dark:hover:bg-slate-600 rounded-lg text-center disabled:opacity-50 disabled:cursor-not-allowed transition-transform hover:scale-105"
           >
             <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 mx-auto text-slate-600 dark:text-slate-300" viewBox="0 0 20 20" fill="currentColor">
               <path d="M8 9a3 3 0 100-6 3 3 0 000 6zM8 11a6 6 0 016 6H2a6 6 0 016-6zM16 7a1 1 0 10-2 0v1h-1a1 1 0 100 2h1v1a1 1 0 102 0v-1h1a1 1 0 100-2h-1V7z" />
@@ -98,10 +98,10 @@ export default function QuickActions() {
             </span>
           </button>
           
-          <button 
+          <button
             onClick={handleDeployApi}
             disabled={isDeploying}
-            className="py-3 px-4 bg-slate-50 dark:bg-slate-700 hover:bg-slate-100 dark:hover:bg-slate-600 rounded-lg text-center disabled:opacity-50 disabled:cursor-not-allowed"
+            className="py-3 px-4 bg-slate-50 dark:bg-slate-700 hover:bg-slate-100 dark:hover:bg-slate-600 rounded-lg text-center disabled:opacity-50 disabled:cursor-not-allowed transition-transform hover:scale-105"
           >
             <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 mx-auto text-slate-600 dark:text-slate-300" viewBox="0 0 20 20" fill="currentColor">
               <path fillRule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM6.293 6.707a1 1 0 010-1.414l3-3a1 1 0 011.414 0l3 3a1 1 0 01-1.414 1.414L11 5.414V13a1 1 0 11-2 0V5.414L7.707 6.707a1 1 0 01-1.414 0z" clipRule="evenodd" />
@@ -111,10 +111,10 @@ export default function QuickActions() {
             </span>
           </button>
           
-          <button 
+          <button
             onClick={handleViewLogs}
             disabled={isViewingLogs}
-            className="py-3 px-4 bg-slate-50 dark:bg-slate-700 hover:bg-slate-100 dark:hover:bg-slate-600 rounded-lg text-center disabled:opacity-50 disabled:cursor-not-allowed"
+            className="py-3 px-4 bg-slate-50 dark:bg-slate-700 hover:bg-slate-100 dark:hover:bg-slate-600 rounded-lg text-center disabled:opacity-50 disabled:cursor-not-allowed transition-transform hover:scale-105"
           >
             <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 mx-auto text-slate-600 dark:text-slate-300" viewBox="0 0 20 20" fill="currentColor">
               <path fillRule="evenodd" d="M3 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clipRule="evenodd" />
@@ -124,10 +124,10 @@ export default function QuickActions() {
             </span>
           </button>
           
-          <button 
+          <button
             onClick={handleConfigureRules}
             disabled={isConfiguring}
-            className="py-3 px-4 bg-slate-50 dark:bg-slate-700 hover:bg-slate-100 dark:hover:bg-slate-600 rounded-lg text-center disabled:opacity-50 disabled:cursor-not-allowed"
+            className="py-3 px-4 bg-slate-50 dark:bg-slate-700 hover:bg-slate-100 dark:hover:bg-slate-600 rounded-lg text-center disabled:opacity-50 disabled:cursor-not-allowed transition-transform hover:scale-105"
           >
             <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 mx-auto text-slate-600 dark:text-slate-300" viewBox="0 0 20 20" fill="currentColor">
               <path fillRule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clipRule="evenodd" />

--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -27,7 +27,7 @@ export default function Header({ toggleSidebar }: HeaderProps) {
   
   return (
     <header
-      className="sticky top-0 z-20 flex items-center justify-between border-b border-transparent bg-gradient-to-r from-blue-600 to-green-500 py-3 px-4 text-white shadow-md dark:from-blue-800 dark:to-green-700"
+      className="sticky top-0 z-20 flex items-center justify-between border-b border-transparent bg-[#2874F0] py-3 px-4 text-white shadow-md"
     >
       <div className="flex items-center">
         <button 
@@ -119,7 +119,7 @@ export default function Header({ toggleSidebar }: HeaderProps) {
         {/* If not authenticated, show login button */}
         {!isAuthenticated && (
           <Link href="/login">
-            <div className="cursor-pointer rounded-md bg-yellow-400 px-4 py-2 text-sm font-medium text-slate-900 hover:bg-yellow-300">
+            <div className="cursor-pointer rounded-md bg-[#FFE500] px-4 py-2 text-sm font-medium text-slate-900 hover:bg-yellow-300">
               Log In
             </div>
           </Link>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2,16 +2,26 @@ import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { getOrders, getOrderDetails, getOrderTracking, getOrderInvoice } from "./routes/orders";
-import { 
-  getProducts, 
-  getProductById, 
-  getProductsByCategory, 
-  searchProducts, 
-  getFeaturedProducts, 
-  getNewArrivals, 
-  getBestSellers, 
-  getProductRecommendations 
+import {
+  getProducts,
+  getProductById,
+  getProductsByCategory,
+  searchProducts,
+  getFeaturedProducts,
+  getNewArrivals,
+  getBestSellers,
+  getProductRecommendations
 } from "./routes/products";
+import {
+  getDashboardLayout,
+  updateDashboardLayout,
+  getDashboardData,
+  getRevenueData,
+  getOrderStats,
+  getTopProducts,
+  getCustomerStats,
+  getSearchTerms,
+} from "./routes/dashboard";
 
 export async function registerRoutes(app: Express): Promise<Server> {
   // Auth routes
@@ -204,11 +214,21 @@ export async function registerRoutes(app: Express): Promise<Server> {
           title: "Account verified",
           message: "Your account has been successfully verified",
           timestamp: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
-          read: true
-        }
-      ]
-    });
+      read: true
+      }
+    ]
   });
+  });
+
+  // Dashboard API routes
+  app.get('/api/dashboard/layouts', getDashboardLayout);
+  app.post('/api/dashboard/layouts', updateDashboardLayout);
+  app.get('/api/dashboard/data', getDashboardData);
+  app.get('/api/dashboard/revenue', getRevenueData);
+  app.get('/api/dashboard/orders/stats', getOrderStats);
+  app.get('/api/dashboard/products/top', getTopProducts);
+  app.get('/api/dashboard/customers/stats', getCustomerStats);
+  app.get('/api/dashboard/search/terms', getSearchTerms);
 
   // Orders API routes
   app.get('/api/orders', getOrders);

--- a/server/routes/dashboard.ts
+++ b/server/routes/dashboard.ts
@@ -1,0 +1,130 @@
+import { Request, Response } from 'express';
+
+export const getDashboardLayout = (req: Request, res: Response) => {
+  res.json({
+    layouts: {
+      default: {
+        widgets: ['revenue', 'orders', 'customers', 'traffic'],
+      },
+    },
+    activeLayout: 'default',
+  });
+};
+
+export const updateDashboardLayout = (req: Request, res: Response) => {
+  res.json(req.body);
+};
+
+export const getDashboardData = (req: Request, res: Response) => {
+  res.json({
+    revenue: {
+      total: 12500,
+      previousTotal: 10000,
+      percentChange: 25,
+      data: [
+        { date: '2024-01-01', revenue: 2000, expenses: 500, profit: 1500 },
+        { date: '2024-01-02', revenue: 3000, expenses: 1000, profit: 2000 },
+      ],
+    },
+    orderStats: {
+      total: 200,
+      pending: 10,
+      processing: 20,
+      shipped: 40,
+      delivered: 120,
+      cancelled: 10,
+      returned: 5,
+      percentChange: 10,
+    },
+    topProducts: [
+      { id: 1, name: 'Product A', category: 'Category A', revenue: 4000, units: 50, percentChange: 5 },
+      { id: 2, name: 'Product B', category: 'Category B', revenue: 3000, units: 40, percentChange: -2 },
+    ],
+    customerStats: {
+      total: 500,
+      newCustomers: 50,
+      returningCustomers: 450,
+      percentChange: 8,
+      sources: {
+        direct: 200,
+        search: 150,
+        social: 50,
+        referral: 50,
+        email: 25,
+        mobile: 15,
+        desktop: 10,
+      },
+    },
+    trafficData: {
+      total: 10000,
+      percentChange: 12,
+      sources: [
+        { source: 'direct', visits: 4000, percentage: 40 },
+        { source: 'search', visits: 3000, percentage: 30 },
+        { source: 'social', visits: 2000, percentage: 20 },
+        { source: 'referral', visits: 1000, percentage: 10 },
+      ],
+    },
+    searchTerms: [
+      { term: 'laptop', count: 120, percentChange: 5 },
+      { term: 'headphones', count: 80, percentChange: 3 },
+    ],
+  });
+};
+
+export const getRevenueData = (req: Request, res: Response) => {
+  res.json({
+    total: 12500,
+    previousTotal: 10000,
+    percentChange: 25,
+    data: [
+      { date: '2024-01-01', revenue: 2000, expenses: 500, profit: 1500 },
+      { date: '2024-01-02', revenue: 3000, expenses: 1000, profit: 2000 },
+    ],
+  });
+};
+
+export const getOrderStats = (req: Request, res: Response) => {
+  res.json({
+    total: 200,
+    pending: 10,
+    processing: 20,
+    shipped: 40,
+    delivered: 120,
+    cancelled: 10,
+    returned: 5,
+    percentChange: 10,
+  });
+};
+
+export const getTopProducts = (req: Request, res: Response) => {
+  res.json([
+    { id: 1, name: 'Product A', category: 'Category A', revenue: 4000, units: 50, percentChange: 5 },
+    { id: 2, name: 'Product B', category: 'Category B', revenue: 3000, units: 40, percentChange: -2 },
+  ]);
+};
+
+export const getCustomerStats = (req: Request, res: Response) => {
+  res.json({
+    total: 500,
+    newCustomers: 50,
+    returningCustomers: 450,
+    percentChange: 8,
+    sources: {
+      direct: 200,
+      search: 150,
+      social: 50,
+      referral: 50,
+      email: 25,
+      mobile: 15,
+      desktop: 10,
+    },
+  });
+};
+
+export const getSearchTerms = (req: Request, res: Response) => {
+  res.json([
+    { term: 'laptop', count: 120, percentChange: 5 },
+    { term: 'headphones', count: 80, percentChange: 3 },
+  ]);
+};


### PR DESCRIPTION
## Summary
- add mock dashboard API endpoints to server
- update header styling to use Flipkart-style colors
- add hover transitions on dashboard MetricCard and QuickActions

## Testing
- `npm test` *(fails: 10 failed, 6 passed)*

------
https://chatgpt.com/codex/tasks/task_e_683f5c3034788323b0f1348dff38b1f2