### PR TITLE
Enhance login UX and persist sessions

### DIFF
--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -3,6 +3,7 @@ import { useLocation } from 'wouter';
 import { useAppSelector } from '@/app/hooks';
 import { selectIsAuthenticated } from '@/features/auth/authSlice';
 import LoginForm from '@/features/auth/components/LoginForm';
+import { Card, CardHeader, CardContent, CardTitle, CardDescription } from '@/components/ui/card';
 
 export default function LoginPage() {
   const isAuthenticated = useAppSelector(selectIsAuthenticated);
@@ -16,27 +17,16 @@ export default function LoginPage() {
   }, [isAuthenticated, setLocation]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 px-4">
-      <div className="w-full max-w-md bg-white dark:bg-gray-800 rounded-lg shadow-md p-8">
-        <div className="mb-6 text-center">
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Sign In</h1>
-          <p className="mt-2 text-gray-600 dark:text-gray-400">
-            Enter your credentials to access your account
-          </p>
-        </div>
-        <LoginForm />
-        <div className="mt-6 text-center">
-          <p className="text-sm text-gray-600 dark:text-gray-400">
-            Don't have an account?{' '}
-            <a 
-              href="/signup" 
-              className="font-medium text-primary hover:text-primary/90 transition-colors"
-            >
-              Sign up
-            </a>
-          </p>
-        </div>
-      </div>
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary/10 to-background px-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <CardTitle>Sign In</CardTitle>
+          <CardDescription>Enter your credentials to access your account</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <LoginForm />
+        </CardContent>
+      </Card>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- refresh Login page UI using Card component and gradient background
- avoid duplicate sign-up link
- persist auth tokens in sessionStorage when "remember me" is not checked
- load tokens from either localStorage or sessionStorage
- clear tokens from both storages on logout
- update social and refresh token handlers to use active storage

## Testing
- `npm test` *(fails: vitest suite issues)*

------
https://chatgpt.com/codex/tasks/task_e_683f5f01779c83239840d939449a7893