### PR TITLE
Fix 404 after login

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -372,7 +372,7 @@ function AppRouter() {
 
         {/* All other routes */}
         {routes
-          .filter(route => route.path !== "/" && route.path !== "/login" && route.path !== "/signup")
+          .filter(route => route.path !== "/" && route.path !== "/login" && route.path !== "/signup" && route.path !== "*")
           .map((route, index) => {
             const Component = route.component;
             const WrappedComponent = () => (
@@ -407,6 +407,9 @@ function AppRouter() {
           ) : (
             <RedirectToLogin />
           )}
+        </Route>
+        <Route>
+          <NotFound />
         </Route>
       </Switch>
       <OfflineIndicator />


### PR DESCRIPTION
## Summary
- fix route filtering so wildcard isn't matched before the dashboard
- add catch-all NotFound route after root path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840a272a3c883238e21917a5356d172