### PR TITLE
Fix search results loading and header theme

### DIFF
--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -27,7 +27,7 @@ export default function Header({ toggleSidebar }: HeaderProps) {
   
   return (
     <header
-      className="sticky top-0 z-20 flex items-center justify-between border-b border-slate-200 dark:border-slate-700 bg-gradient-to-r from-primary-600 to-blue-700 px-4 py-2 text-white shadow-sm backdrop-blur-md"
+      className="sticky top-0 z-20 flex items-center justify-between border-b border-slate-200 dark:border-slate-700 bg-gradient-to-r from-gray-800 via-gray-900 to-gray-800 px-4 py-2 text-white shadow-sm backdrop-blur-md"
     >
       <div className="flex items-center">
         <button 

--- a/client/src/features/products/MockProductsComponent.tsx
+++ b/client/src/features/products/MockProductsComponent.tsx
@@ -290,7 +290,12 @@ const MockProductsComponent: React.FC<MockProductsComponentProps> = ({
       )}
       
       {/* Product grid */}
-      {currentProducts.length === 0 ? (
+      {loading && currentProducts.length === 0 ? (
+        <div className="flex items-center justify-center p-8">
+          <Loader2 className="h-6 w-6 animate-spin text-primary mr-2" />
+          <span>Loading products...</span>
+        </div>
+      ) : filteredProducts.length === 0 && !loading ? (
         <div className="flex flex-col items-center justify-center p-8 bg-gray-50 dark:bg-gray-800/50 rounded-lg">
           <h3 className="text-xl font-semibold mb-2">No products found</h3>
           <p className="text-gray-500 dark:text-gray-400 text-center">


### PR DESCRIPTION
## Summary
- tweak header with a darker gradient style
- prevent flicker of "No products found" in search results
- show a loader while products are loading

## Testing
- `./run-tests.sh` *(fails: vitest missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840b2d3509083239335f5f49241acd8