### PR TITLE
Fix React Router integration

### DIFF
--- a/client/src/components/layout/Breadcrumb.tsx
+++ b/client/src/components/layout/Breadcrumb.tsx
@@ -1,5 +1,5 @@
-import { useLocation } from 'wouter';
-import { Link } from 'wouter';
+import { useLocation } from '@/router/wouterCompat';
+import { Link } from '@/router/wouterCompat';
 import { routes } from '@/App';
 import { cn } from '@/lib/utils';
 

--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -7,7 +7,7 @@ import UserMenu from '@/components/ui/UserMenu';
 import ThemeToggle from '@/components/ui/ThemeToggle';
 import GlobalSearch from '@/features/search/components/GlobalSearch';
 import { cn } from '@/lib/utils';
-import { Link } from 'wouter';
+import { Link } from '@/router/wouterCompat';
 import { ShoppingCart, Heart } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 

--- a/client/src/components/layout/Layout.tsx
+++ b/client/src/components/layout/Layout.tsx
@@ -1,15 +1,13 @@
 import { useState, useEffect } from 'react';
+import { Outlet } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import Header from './Header';
 import Sidebar from './Sidebar';
 import Breadcrumb from './Breadcrumb';
 import { useMobileDetect } from '@/app/hooks';
-import { useLocation } from 'wouter';
+import { useLocation } from '@/router/wouterCompat';
 import { fetchCart } from '@/features/cart/cartSlice';
 
-interface LayoutProps {
-  children: React.ReactNode;
-}
 
 interface NotificationProps {
   message: string;
@@ -53,7 +51,7 @@ const NotificationBar = ({ message, type, onClose }: NotificationProps) => {
   );
 };
 
-export default function Layout({ children }: LayoutProps) {
+export default function Layout() {
   const dispatch = useDispatch();
   const isMobile = useMobileDetect();
   const [sidebarOpen, setSidebarOpen] = useState(!isMobile);
@@ -131,7 +129,7 @@ export default function Layout({ children }: LayoutProps) {
             {/* Banner Slot - for future use */}
             <div id="banner-slot"></div>
             
-            {children}
+            <Outlet />
           </main>
         </div>
       </div>

--- a/client/src/components/layout/Sidebar.tsx
+++ b/client/src/components/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link, useLocation } from 'wouter';
+import { Link, useLocation } from '@/router/wouterCompat';
 import { useAppSelector, useAppDispatch } from '@/app/hooks';
 import { selectUserRole, setAuthState, logout } from '@/features/auth/authSlice';
 import { cn } from '@/lib/utils';

--- a/client/src/components/ui/NotificationMenu.tsx
+++ b/client/src/components/ui/NotificationMenu.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { Bell, CheckCheck, Check, Trash2 } from 'lucide-react';
-import { Link } from 'wouter';
+import { Link } from '@/router/wouterCompat';
 import { formatTimeAgo } from '@/lib/utils';
 import { 
   selectNotifications, 

--- a/client/src/components/ui/UserMenu.tsx
+++ b/client/src/components/ui/UserMenu.tsx
@@ -3,7 +3,7 @@ import { useAppDispatch } from '@/app/hooks';
 import { logout } from '@/features/auth/authSlice';
 import { cn } from '@/lib/utils';
 import { User } from '@/features/auth/types';
-import { Link } from 'wouter';
+import { Link } from '@/router/wouterCompat';
 
 interface UserMenuProps {
   user: User;

--- a/client/src/components/ui/header.tsx
+++ b/client/src/components/ui/header.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link, useLocation } from 'wouter';
+import { Link, useLocation } from '@/router/wouterCompat';
 import { useSelector } from 'react-redux';
 import { 
   Search, 

--- a/client/src/features/auth/LoginForm.tsx
+++ b/client/src/features/auth/LoginForm.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useLocation } from 'wouter';
+import { useLocation } from '@/router/wouterCompat';
 import { useAuth } from './authHooks';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';

--- a/client/src/features/auth/ProtectedRoute.tsx
+++ b/client/src/features/auth/ProtectedRoute.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useEffect } from 'react';
-import { useLocation, useRoute, Redirect } from 'wouter';
+import { useLocation, useRoute, Redirect } from '@/router/wouterCompat';
 import { useAppSelector } from '@/app/hooks';
 import { selectIsAuthenticated, selectUserRole } from './authSlice';
 import { canAccessRoute } from './rbac';

--- a/client/src/features/auth/SignupForm.tsx
+++ b/client/src/features/auth/SignupForm.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useLocation } from 'wouter';
+import { useLocation } from '@/router/wouterCompat';
 import { useAuth } from './authHooks';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';

--- a/client/src/features/auth/authHooks.ts
+++ b/client/src/features/auth/authHooks.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useLocation } from 'wouter';
+import { useLocation } from '@/router/wouterCompat';
 import { useAppSelector, useAppDispatch } from '@/app/hooks';
 import { 
   selectIsAuthenticated, 

--- a/client/src/features/auth/components/LoginForm.tsx
+++ b/client/src/features/auth/components/LoginForm.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useLocation } from 'wouter';
+import { useLocation } from '@/router/wouterCompat';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';

--- a/client/src/features/auth/components/LogoutButton.tsx
+++ b/client/src/features/auth/components/LogoutButton.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useLocation } from 'wouter';
+import { useLocation } from '@/router/wouterCompat';
 import { Button } from '@/components/ui/button';
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
 import { logout, selectAuthStatus } from '../authSlice';

--- a/client/src/features/auth/components/SignupForm.tsx
+++ b/client/src/features/auth/components/SignupForm.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useLocation } from 'wouter';
+import { useLocation } from '@/router/wouterCompat';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';

--- a/client/src/features/auth/components/signup/ReviewStep.tsx
+++ b/client/src/features/auth/components/signup/ReviewStep.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useLocation } from 'wouter';
+import { useLocation } from '@/router/wouterCompat';
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
 import { 
   selectSignupFormData, 

--- a/client/src/features/cart/components/CartItem.tsx
+++ b/client/src/features/cart/components/CartItem.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { Link } from 'wouter';
+import { Link } from '@/router/wouterCompat';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import {

--- a/client/src/features/cart/components/CartPage.tsx
+++ b/client/src/features/cart/components/CartPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Link } from 'wouter';
+import { Link } from '@/router/wouterCompat';
 import { useDispatch } from 'react-redux';
 import { useAppSelector } from '@/app/hooks';
 import { RootState } from '@/app/store';

--- a/client/src/features/cart/components/CartSummary.tsx
+++ b/client/src/features/cart/components/CartSummary.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'wouter';
+import { Link } from '@/router/wouterCompat';
 import { Card, CardContent, CardFooter } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';

--- a/client/src/features/cart/components/EmptyCart.tsx
+++ b/client/src/features/cart/components/EmptyCart.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'wouter';
+import { Link } from '@/router/wouterCompat';
 import { ShoppingCart, ArrowRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';

--- a/client/src/features/cart/components/MockCartPage.tsx
+++ b/client/src/features/cart/components/MockCartPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useLocation } from 'wouter';
+import { useLocation } from '@/router/wouterCompat';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { Input } from '@/components/ui/input';

--- a/client/src/features/checkout/components/Checkout.tsx
+++ b/client/src/features/checkout/components/Checkout.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useLocation } from 'wouter';
+import { useLocation } from '@/router/wouterCompat';
 import { Container } from '@/components/ui/container';
 import { Separator } from '@/components/ui/separator';
 import { Card, CardContent } from '@/components/ui/card';

--- a/client/src/features/checkout/components/OrderConfirmation.tsx
+++ b/client/src/features/checkout/components/OrderConfirmation.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Link } from 'wouter';
+import { Link } from '@/router/wouterCompat';
 import {
   Card,
   CardContent,

--- a/client/src/features/content/components/banners/BannerDisplay.tsx
+++ b/client/src/features/content/components/banners/BannerDisplay.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import { Link } from 'wouter';
+import { Link } from '@/router/wouterCompat';
 import { Banner, BannerPosition } from '../../types';
 import { useGetBannersByPositionQuery, useTrackBannerViewMutation } from '../../contentApi';
 import { setActiveBanner } from '../../contentSlice';

--- a/client/src/features/content/components/browse/VideoGrid.tsx
+++ b/client/src/features/content/components/browse/VideoGrid.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'wouter';
+import { Link } from '@/router/wouterCompat';
 import { Video } from '../../types';
 import { useDispatch } from 'react-redux';
 import { setCurrentVideo, setIsPlaying } from '../../contentSlice';

--- a/client/src/features/navigation/NavigationToast.test.tsx
+++ b/client/src/features/navigation/NavigationToast.test.tsx
@@ -5,10 +5,10 @@ import { navigateTo } from './navigationSlice';
 import * as hooks from '@/hooks/use-toast';
 import { act } from '@testing-library/react';
 
-// Mock the useLocation hook from wouter
+// Mock the useLocation hook from the router
 let useLocationMock: ReturnType<typeof vi.fn>;
-vi.mock('wouter', async () => {
-  const actual = await vi.importActual('wouter');
+vi.mock('@/router/wouterCompat', async () => {
+  const actual = await vi.importActual('@/router/wouterCompat');
   return {
     ...actual,
     useLocation: (...args: any[]) => useLocationMock(...args),

--- a/client/src/features/navigation/NavigationToast.tsx
+++ b/client/src/features/navigation/NavigationToast.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useLocation } from 'wouter';
+import { useLocation } from '@/router/wouterCompat';
 import { useDispatch, useSelector } from 'react-redux';
 import { useToast } from '@/hooks/use-toast';
 import { navigateTo, selectCurrentPath } from './navigationSlice';

--- a/client/src/features/orders/components/DraggableOrderList.tsx
+++ b/client/src/features/orders/components/DraggableOrderList.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link } from 'wouter';
+import { Link } from '@/router/wouterCompat';
 import { format } from 'date-fns';
 import {
   DndContext, 

--- a/client/src/features/orders/components/OrderDetails.tsx
+++ b/client/src/features/orders/components/OrderDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useParams, Link } from 'wouter';
+import { useParams, Link } from '@/router/wouterCompat';
 import { format } from 'date-fns';
 import {
   useGetOrderDetailsQuery,

--- a/client/src/features/orders/components/OrderList.tsx
+++ b/client/src/features/orders/components/OrderList.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link } from 'wouter';
+import { Link } from '@/router/wouterCompat';
 import { format } from 'date-fns';
 import {
   Table,

--- a/client/src/features/orders/components/OrdersPage.tsx
+++ b/client/src/features/orders/components/OrdersPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Switch, Route, useRoute } from 'wouter';
+import { Switch, Route, useRoute } from '@/router/wouterCompat';
 import { Container } from '@/components/ui/container';
 import OrderList from './OrderList';
 import OrderDetails from './OrderDetails';
@@ -54,9 +54,9 @@ export default function OrdersPage() {
   return (
     <Container>
       <Switch>
-        <Route path="/orders" component={OrderList} />
-        <Route path="/orders/:id" component={OrderDetails} />
-        <Route path="/orders/:orderId/return/:itemId" component={ReturnItemForm} />
+        <Route path="/orders" element={<OrderList />} />
+        <Route path="/orders/:id" element={<OrderDetails />} />
+        <Route path="/orders/:orderId/return/:itemId" element={<ReturnItemForm />} />
       </Switch>
     </Container>
   );

--- a/client/src/features/orders/components/ReturnItemForm.tsx
+++ b/client/src/features/orders/components/ReturnItemForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useParams, Link, useLocation } from 'wouter';
+import { useParams, Link, useLocation } from '@/router/wouterCompat';
 import {
   useGetOrderDetailsQuery,
   useSubmitReturnRequestMutation,

--- a/client/src/features/products/MockProductsComponent.tsx
+++ b/client/src/features/products/MockProductsComponent.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import { useLocation } from 'wouter';
+import { useLocation } from '@/router/wouterCompat';
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";

--- a/client/src/features/products/components/EnhancedProductsComponent.tsx
+++ b/client/src/features/products/components/EnhancedProductsComponent.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { useLocation } from 'wouter';
+import { useLocation } from '@/router/wouterCompat';
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";

--- a/client/src/features/products/components/ExtendedProductsPage.tsx
+++ b/client/src/features/products/components/ExtendedProductsPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Link } from 'wouter';
+import { Link } from '@/router/wouterCompat';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';

--- a/client/src/features/products/components/ProductDetailPage.tsx
+++ b/client/src/features/products/components/ProductDetailPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useRoute } from 'wouter';
+import { useRoute } from '@/router/wouterCompat';
 import { useGetProductByIdQuery } from '../productsApi';
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
 import { uploadProductImages, clearImageUploadState } from '../productsSlice';

--- a/client/src/features/products/components/ProductDetails.test.tsx
+++ b/client/src/features/products/components/ProductDetails.test.tsx
@@ -5,13 +5,13 @@ import { renderWithProviders } from '@/test/test-utils';
 import * as api from '../productsApi';
 import * as hooks from '@/app/hooks';
 import { useToast } from '@/hooks/use-toast';
-import * as wouter from 'wouter';
+import * as wouter from '@/router/wouterCompat';
 
 vi.mock('../productsApi');
 vi.mock('@/app/hooks');
 vi.mock('@/hooks/use-toast');
-vi.mock('wouter', async () => {
-  const actual = await vi.importActual<typeof import('wouter')>('wouter');
+vi.mock('@/router/wouterCompat', async () => {
+  const actual = await vi.importActual<typeof import('@/router/wouterCompat')>('@/router/wouterCompat');
   return {
     ...actual,
     useParams: vi.fn(),

--- a/client/src/features/products/components/ProductDetails.tsx
+++ b/client/src/features/products/components/ProductDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useParams, Link } from 'wouter';
+import { useParams, Link } from '@/router/wouterCompat';
 import { useAppDispatch } from '@/app/hooks';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';

--- a/client/src/features/products/components/ProductGrid.tsx
+++ b/client/src/features/products/components/ProductGrid.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, memo } from 'react';
 import { useGetProductsQuery } from '../productsApi';
-import { useLocation } from 'wouter';
+import { useLocation } from '@/router/wouterCompat';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Star, Heart, ShoppingCart } from 'lucide-react';

--- a/client/src/features/products/components/ProductRecommendations.tsx
+++ b/client/src/features/products/components/ProductRecommendations.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'wouter';
+import { Link } from '@/router/wouterCompat';
 import { Product } from '../productsApi';
 import { useDispatch, useSelector } from 'react-redux';
 import { selectProduct, selectRecentlyViewedIds } from '../productsSlice';

--- a/client/src/features/products/components/SimpleProductGrid.tsx
+++ b/client/src/features/products/components/SimpleProductGrid.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation } from 'wouter';
+import { useLocation } from '@/router/wouterCompat';
 import { formatCurrency } from '@/lib/utils';
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";

--- a/client/src/features/reviews/pages/ReviewsPage.tsx
+++ b/client/src/features/reviews/pages/ReviewsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useParams } from 'wouter';
+import { useParams } from '@/router/wouterCompat';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Card } from '@/components/ui/card';

--- a/client/src/features/search/components/GlobalSearch.tsx
+++ b/client/src/features/search/components/GlobalSearch.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useLocation } from 'wouter';
+import { useLocation } from '@/router/wouterCompat';
 import { useDebounce } from '@/hooks/useDebounce';
 import { 
   setQuery, 

--- a/client/src/features/search/pages/SearchResults.tsx
+++ b/client/src/features/search/pages/SearchResults.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useLocation } from 'wouter';
+import { useLocation } from '@/router/wouterCompat';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Filter, ArrowLeft } from 'lucide-react';

--- a/client/src/features/wishlist/components/EmptyWishlist.tsx
+++ b/client/src/features/wishlist/components/EmptyWishlist.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'wouter';
+import { Link } from '@/router/wouterCompat';
 import { Heart, ArrowRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';

--- a/client/src/features/wishlist/components/WishlistItem.tsx
+++ b/client/src/features/wishlist/components/WishlistItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
-import { Link } from 'wouter';
+import { Link } from '@/router/wouterCompat';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import {

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -6,6 +6,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from '@/lib/queryClient';
 import { ThemeProvider } from '@/providers/ThemeProvider';
 import App from './App';
+import { Router } from '@/router/wouterCompat';
 import './index.css';
 
 const root = createRoot(document.getElementById('root')!);
@@ -15,7 +16,9 @@ root.render(
     <Provider store={store}>
       <QueryClientProvider client={queryClient}>
         <ThemeProvider>
-          <App />
+          <Router>
+            <App />
+          </Router>
         </ThemeProvider>
       </QueryClientProvider>
     </Provider>

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useLocation } from 'wouter';
+import { useLocation } from '@/router/wouterCompat';
 import { useAppSelector } from '@/app/hooks';
 import { selectIsAuthenticated } from '@/features/auth/authSlice';
 import LoginForm from '@/features/auth/components/LoginForm';

--- a/client/src/pages/SignupPage.tsx
+++ b/client/src/pages/SignupPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useLocation } from 'wouter';
+import { useLocation } from '@/router/wouterCompat';
 import { useAuth } from '@/features/auth';
 import SignupWizard from '@/features/auth/components/signup/SignupWizard';
 import { useAppDispatch } from '@/app/hooks';

--- a/client/src/router/ScrollToTop.tsx
+++ b/client/src/router/ScrollToTop.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}

--- a/client/src/router/wouterCompat.tsx
+++ b/client/src/router/wouterCompat.tsx
@@ -1,0 +1,28 @@
+import {
+  BrowserRouter,
+  Routes as RRRoutes,
+  Route as RRRoute,
+  Navigate,
+  useLocation as rrUseLocation,
+  useNavigate,
+  matchPath,
+  Link,
+  useParams,
+} from 'react-router-dom';
+
+export { BrowserRouter as Router, Navigate as Redirect, Link, useParams };
+
+export const Switch = RRRoutes;
+export const Route = RRRoute;
+
+export function useLocation(): [string, (to: string) => void] {
+  const location = rrUseLocation();
+  const navigate = useNavigate();
+  return [location.pathname, (to: string) => navigate(to)];
+}
+
+export function useRoute(pattern: string): [boolean, any] {
+  const location = rrUseLocation();
+  const match = matchPath(pattern, location.pathname);
+  return [match != null, match ? match.params : null];
+}

--- a/client/src/test/test-utils.tsx
+++ b/client/src/test/test-utils.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react';
 import { render, RenderOptions } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
-import { Router } from 'wouter';
+import { Router } from '@/router/wouterCompat';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@/providers/ThemeProvider';
 import { vi } from 'vitest';

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,7 @@
         "react-icons": "^5.5.0",
         "react-redux": "^9.2.0",
         "react-resizable-panels": "^2.1.7",
+        "react-router-dom": "^7.6.2",
         "react-virtualized-auto-sizer": "^1.0.26",
         "react-window": "^1.8.11",
         "recharts": "^2.15.2",
@@ -8930,6 +8931,53 @@
         "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.2.tgz",
+      "integrity": "sha512-U7Nv3y+bMimgWjhlT5CRdzHPu2/KVmqPwKUCChW8en5P3znxUqwlYFlbmyj8Rgp1SF6zs5X4+77kBVknkg6a0w==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.2.tgz",
+      "integrity": "sha512-Q8zb6VlTbdYKK5JJBLQEN06oTUa/RAbG/oQS1auK1I0TbJOXktqm+QENEVJU6QvWynlXPRBXI3fiOQcSEA78rA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/react-side-effect": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
@@ -9353,6 +9401,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "react-icons": "^5.5.0",
     "react-redux": "^9.2.0",
     "react-resizable-panels": "^2.1.7",
+    "react-router-dom": "^7.6.2",
     "react-virtualized-auto-sizer": "^1.0.26",
     "react-window": "^1.8.11",
     "recharts": "^2.15.2",


### PR DESCRIPTION
## Summary
- re-export React Router components directly to avoid `<Routes>` errors
- update routing setup to use `element` props
- adjust tests to mock new router module

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f753774c8323b71937669877ffce