### PR TITLE
Fix runtime error with Route component

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -350,28 +350,40 @@ function AppRouter() {
   const routesContent = (
     <ErrorBoundary>
       <Switch>
-        <Route path="/login">
-          {isAuthenticated ? (
-            <Redirect to="/" />
-          ) : (
-            <Suspense fallback={<GlobalLoadingFallback />}>
-              <LoginPage />
-            </Suspense>
-          )}
-        </Route>
-        <Route path="/signup">
-          {isAuthenticated ? (
-            <Redirect to="/" />
-          ) : (
-            <Suspense fallback={<GlobalLoadingFallback />}>
-              <SignupPage />
-            </Suspense>
-          )}
-        </Route>
-        <Route path="/" component={Layout}>
-          <Route index component={Dashboard} />
+        <Route
+          path="/login"
+          element={
+            isAuthenticated ? (
+              <Redirect to="/" />
+            ) : (
+              <Suspense fallback={<GlobalLoadingFallback />}>
+                <LoginPage />
+              </Suspense>
+            )
+          }
+        />
+        <Route
+          path="/signup"
+          element={
+            isAuthenticated ? (
+              <Redirect to="/" />
+            ) : (
+              <Suspense fallback={<GlobalLoadingFallback />}>
+                <SignupPage />
+              </Suspense>
+            )
+          }
+        />
+        <Route path="/" element={<Layout />}>
+          <Route index element={<Dashboard />} />
           {routes
-            .filter(route => route.path !== "/" && route.path !== "/login" && route.path !== "/signup" && route.path !== "*")
+            .filter(
+              route =>
+                route.path !== "/" &&
+                route.path !== "/login" &&
+                route.path !== "/signup" &&
+                route.path !== "*"
+            )
             .map((route, index) => {
               const Component = route.component;
               const WrappedComponent = () => (
@@ -383,16 +395,20 @@ function AppRouter() {
               );
 
               return route.requireAuth ? (
-                <Route key={index} path={route.path}>
-                  <ProtectedRoute roles={route.roles}>
-                    <WrappedComponent />
-                  </ProtectedRoute>
-                </Route>
+                <Route
+                  key={index}
+                  path={route.path}
+                  element={
+                    <ProtectedRoute roles={route.roles}>
+                      <WrappedComponent />
+                    </ProtectedRoute>
+                  }
+                />
               ) : (
-                <Route key={index} path={route.path} component={WrappedComponent} />
+                <Route key={index} path={route.path} element={<WrappedComponent />} />
               );
             })}
-          <Route path="*" component={NotFound} />
+          <Route path="*" element={<NotFound />} />
         </Route>
       </Switch>
       <OfflineIndicator />

--- a/client/src/features/orders/components/OrdersPage.tsx
+++ b/client/src/features/orders/components/OrdersPage.tsx
@@ -54,9 +54,9 @@ export default function OrdersPage() {
   return (
     <Container>
       <Switch>
-        <Route path="/orders" component={OrderList} />
-        <Route path="/orders/:id" component={OrderDetails} />
-        <Route path="/orders/:orderId/return/:itemId" component={ReturnItemForm} />
+        <Route path="/orders" element={<OrderList />} />
+        <Route path="/orders/:id" element={<OrderDetails />} />
+        <Route path="/orders/:orderId/return/:itemId" element={<ReturnItemForm />} />
       </Switch>
     </Container>
   );

--- a/client/src/router/wouterCompat.tsx
+++ b/client/src/router/wouterCompat.tsx
@@ -1,38 +1,22 @@
 import React from 'react';
 import {
   BrowserRouter,
-  Routes as RRRoutes,
-  Route as RRRoute,
+  Routes,
+  Route,
   Navigate,
+  Link,
   useLocation as rrUseLocation,
   useNavigate,
-  matchPath
+  matchPath,
+  useParams
 } from 'react-router-dom';
 
-export { BrowserRouter as Router, Navigate as Redirect };
-export { Link } from 'react-router-dom';
-export { useParams } from 'react-router-dom';
+export { BrowserRouter as Router, Navigate as Redirect, Link, Route };
+// Alias React Router's Routes as Switch for wouter compatibility
+export { Routes as Switch } from 'react-router-dom';
+export { useParams };
 
-export function Switch({ children }: { children: React.ReactNode }) {
-  return <RRRoutes>{children}</RRRoutes>;
-}
-
-interface RouteProps {
-  path: string;
-  component?: React.ComponentType<any>;
-  children?: React.ReactNode;
-  index?: boolean;
-}
-
-export function Route({ path, component: Component, children, index }: RouteProps) {
-  const element = Component ? <Component /> : undefined;
-  return (
-    <RRRoute path={path} element={element} index={index}>
-      {children}
-    </RRRoute>
-  );
-}
-
+// Custom hooks to mimic wouter's return signatures
 export function useLocation(): [string, (to: string) => void] {
   const location = rrUseLocation();
   const navigate = useNavigate();


### PR DESCRIPTION
## Summary
- export `Route` and `Routes` directly from `react-router-dom`
- update routing code in `App` and `OrdersPage` to use `element` prop

## Testing
- `npm run check` *(fails: numerous type errors)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ff9c9de883238a08cc9b5dbc2127